### PR TITLE
Fix multi-head detection training and results

### DIFF
--- a/tests/test_multihead.py
+++ b/tests/test_multihead.py
@@ -8,6 +8,8 @@ from ultralytics import YOLO
 from ultralytics.data.utils import check_det_dataset
 from ultralytics.models.yolo.detect.val import DetectionValidator
 from ultralytics.utils import ops, loss
+from ultralytics.data.dataset import YOLODataset
+from ultralytics.engine.results import Boxes
 from ultralytics.utils.metrics import DetMetrics, ConfusionMatrix
 from tests import TMP
 from ultralytics.nn.tasks import yaml_model_load
@@ -241,6 +243,18 @@ def test_v8_detection_loss_singlehead():
     assert total >= 0
 
 
+def test_confidence_gradients_flow():
+    model = DummyModel(num_classes_per_head=[2, 1])
+    crit = loss.v8DetectionLoss(model)
+    x = [torch.randn(1, 8, 4, 4, requires_grad=True) for _ in range(3)]
+    preds = model.model[-1](x)
+    batch = {"batch_idx": torch.tensor([0]), "cls": torch.tensor([0]), "bboxes": torch.tensor([[0.5, 0.5, 0.2, 0.2]])}
+    total, _ = crit(preds, batch)
+    total.backward()
+    grad = model.model[-1].cv3[0][0][-1].bias.grad
+    assert grad.abs().sum() > 0
+
+
 def create_sample_dataset(num_images=5, image_size=(64, 64), multihead=True):
     root = TMP / ("multihead_data" if multihead else "singlehead_data")
     shutil.rmtree(root, ignore_errors=True)
@@ -287,6 +301,24 @@ def create_sample_dataset(num_images=5, image_size=(64, 64), multihead=True):
         open(yaml_path, "w", encoding="utf-8"),
     )
     return root, yaml_path, names
+
+
+def test_multihead_label_shape():
+    root, yaml_file, names = create_sample_dataset(num_images=1)
+    data = check_det_dataset(yaml_file, autodownload=False)
+    dataset = YOLODataset(img_path=str(root / "images/train"), imgsz=64, batch_size=1, data=data)
+    assert dataset.labels[0]["cls"].shape[1] == len(names)
+
+
+def test_results_access_multihead():
+    b = Boxes(torch.tensor([[0, 0, 10, 10, 0.9, 0, 0.8, 1]]), orig_shape=(64, 64))
+    assert b.get_head_predictions(1)[0] == b.conf2
+    assert b.get_head_predictions(1)[1] == b.cls2
+
+
+def test_results_access_singlehead():
+    b = Boxes(torch.tensor([[0, 0, 10, 10, 0.5, 1]]), orig_shape=(64, 64))
+    assert b.conf is not None and b.cls is not None
 
 
 import pytest

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -116,12 +116,21 @@ class YOLODataset(BaseDataset):
                         valid_mask = (boxes_pix[:,2] >= self.min_size) & (boxes_pix[:,3] >= self.min_size)
                         lb = lb[valid_mask]
                     
+                    num_heads = len(self.data.get("nc_per_task", []))
+                    cls_cols = lb[:, :num_heads] if num_heads else lb[:, 0:1]
+                    bboxes = lb[:, num_heads : num_heads + 4]
+                    if not x["labels"] and num_heads:
+                        print(
+                            f"Dataset contains {num_heads} heads with {self.data.get('nc_per_task')} classes each"
+                        )
+                        print(f"Sample label tensor shape: {lb.shape}")
+                        print(f"Expected shape: (N, {sum(self.data.get('nc_per_task', [])) + 4})")
                     x["labels"].append(
                         {
                             "im_file": im_file,
                             "shape": shape,
-                            "cls": lb[:, 0:1],  # n, 1
-                            "bboxes": lb[:, 1:],  # n, 4
+                            "cls": cls_cols,
+                            "bboxes": bboxes,
                             "segments": segments,
                             "keypoints": keypoint,
                             "normalized": True,

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -124,11 +124,12 @@ def verify_image_label(args, min_size=25):
             nf = 1  # label found
             with open(lb_file) as f:
                 lb = [x.split() for x in f.read().strip().splitlines() if len(x)]
-                if any(len(x) > 6 for x in lb) and (not keypoint):  # is segment
-                    classes = np.array([x[0] for x in lb], dtype=np.float32)
-                    segments = [np.array(x[1:], dtype=np.float32).reshape(-1, 2) for x in lb]  # (cls, xy1...)
-                    lb = np.concatenate((classes.reshape(-1, 1), segments2boxes(segments)), 1)  # (cls, xywh)
-                lb = np.array(lb, dtype=np.float32)
+            if any(len(x) > 6 for x in lb) and (not keypoint):  # is segment
+                classes = np.array([x[0] for x in lb], dtype=np.float32)
+                segments = [np.array(x[1:], dtype=np.float32).reshape(-1, 2) for x in lb]  # (cls, xy1...)
+                lb = np.concatenate((classes.reshape(-1, 1), segments2boxes(segments)), 1)  # (cls, xywh)
+            lb = np.array(lb, dtype=np.float32)
+            original_shape = lb.shape
             nl = len(lb)
             if nl:
                 if keypoint:
@@ -174,8 +175,10 @@ def verify_image_label(args, min_size=25):
                 kpt_mask = np.where((keypoints[..., 0] < 0) | (keypoints[..., 1] < 0), 0.0, 1.0).astype(np.float32)
                 keypoints = np.concatenate([keypoints, kpt_mask[..., None]], axis=-1)  # (nl, nkpt, 3)
         if is_multihead:
-            # drop extra class columns when returning YOLO-format labels
-            lb = np.concatenate([lb[:, :1], lb[:, len(num_cls_per_head) : len(num_cls_per_head) + 4]], 1)
+            processed_shape = lb.shape
+            print(f"Original labels shape: {original_shape}, Processed: {processed_shape}")
+            # keep all class columns for multi-head
+            lb = lb[:, : len(num_cls_per_head) + 4]
         else:
             lb = lb[:, :5]
         return im_file, lb, shape, segments, keypoints, nm, nf, ne, nc, msg

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -1003,21 +1003,37 @@ class Boxes(BaseTensor):
         if boxes.ndim == 1:
             boxes = boxes[None, :]
         n = boxes.shape[-1]
-        
-      # Standard detection format
-        if n in {6, 7}:
-            super().__init__(boxes, orig_shape)
-            self.is_track = n == 7
-            self.orig_shape = orig_shape
 
-        # Dual-class detection format
-        elif n in {8, 9}:
-            super().__init__(boxes, orig_shape)
-            self.is_track = n == 9
-            self.orig_shape = orig_shape
-
+        if (n - 4) % 2 == 0:
+            self.is_track = False
+            self.num_heads = (n - 4) // 2
+        elif (n - 5) % 2 == 0:
+            self.is_track = True
+            self.num_heads = (n - 5) // 2
         else:
-            raise AssertionError(f"Expected box data to have 6, 7, 8, or 9 columns. Got {n}")
+            raise AssertionError(f"Unexpected box column count {n}")
+        super().__init__(boxes, orig_shape)
+        self.orig_shape = orig_shape
+
+    def get_head_predictions(self, head_idx):
+        """Return confidence and class columns for a specific head."""
+        base = 4 + head_idx * 2
+        if self.is_track:
+            conf = self.data[:, base]
+            cls = self.data[:, base + 1]
+        else:
+            conf = self.data[:, base]
+            cls = self.data[:, base + 1]
+        return conf, cls
+
+    def __getattr__(self, name):
+        if name.startswith("conf") and name[4:].isdigit():
+            idx = int(name[4:])
+            return self.get_head_predictions(idx)[0]
+        if name.startswith("cls") and name[3:].isdigit():
+            idx = int(name[3:])
+            return self.get_head_predictions(idx)[1]
+        return super().__getattr__(name)
 
     @property
     def xyxy(self):
@@ -1051,7 +1067,7 @@ class Boxes(BaseTensor):
             >>> print(conf_scores)
             tensor([0.9000])
         """
-        return self.data[:, 4]
+        return self.get_head_predictions(0)[0]
 
     @property
     def cls(self):
@@ -1068,22 +1084,20 @@ class Boxes(BaseTensor):
             >>> class_ids = boxes.cls
             >>> print(class_ids)  # tensor([0., 2., 1.])
         """
-        return self.data[:, 5]
+        return self.get_head_predictions(0)[1]
 
     @property
     def conf2(self):
         """Returns secondary confidence scores (if available)."""
-        n = self.data.shape[-1]
-        if n >= 8:
-            return self.data[:, 6]
+        if self.num_heads > 1:
+            return self.get_head_predictions(1)[0]
         return None
 
     @property
     def cls2(self):
         """Returns secondary class labels (if available)."""
-        n = self.data.shape[-1]
-        if n >= 8:
-            return self.data[:, 7]
+        if self.num_heads > 1:
+            return self.get_head_predictions(1)[1]
         return None
     
     @property
@@ -1110,10 +1124,8 @@ class Boxes(BaseTensor):
             - The tracking IDs are typically used to associate detections across multiple frames in video analysis.
         """
         n = self.data.shape[-1]
-        if n == 9 and self.is_track:
-            return self.data[:, 8]
-        if n == 7 and self.is_track:
-            return self.data[:, 6]
+        if self.is_track:
+            return self.data[:, 4 + 2 * self.num_heads]
         return None
 
     @property

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -253,10 +253,10 @@ class v8DetectionLoss:
         self.is_multihead = self.num_classes_per_head is not None
         if self.is_multihead:
             self.bce = nn.ModuleList(nn.BCEWithLogitsLoss(reduction="none") for _ in self.num_classes_per_head)
-            self.bce_all = nn.BCEWithLogitsLoss(reduction="none")
             self.class_offsets = [0]
             for nc_i in self.num_classes_per_head:
                 self.class_offsets.append(self.class_offsets[-1] + nc_i)
+            self.bce_obj = nn.BCEWithLogitsLoss(reduction="none")
         else:
             self.bce = nn.BCEWithLogitsLoss(reduction="none")
         self.hyp = h
@@ -312,12 +312,14 @@ class v8DetectionLoss:
 
         if self.is_multihead:
             start = 0
-            cls_parts = []
+            cls_parts, conf_parts = [], []
             for nc_i in self.num_classes_per_head:
-                start += 1  # skip conf
+                conf_parts.append(pred_cls_all[:, :, start : start + 1])
+                start += 1
                 cls_parts.append(pred_cls_all[:, :, start : start + nc_i])
                 start += nc_i
             pred_scores = torch.cat(cls_parts, 2)
+            pred_confs = conf_parts
         else:
             pred_scores = pred_cls_all
 
@@ -349,19 +351,25 @@ class v8DetectionLoss:
 
         target_scores_sum = max(target_scores.sum(), 1)
 
-        # cls loss
+        # cls and conf loss
         if isinstance(self.bce, (nn.BCEWithLogitsLoss, FocalLoss, nn.ModuleList)):
             if self.is_multihead:
                 start = 0
-                cls_losses = []
+                cls_losses, conf_losses = [], []
+                conf_tgt = fg_mask.float().unsqueeze(-1)
                 for i, nc_i in enumerate(self.num_classes_per_head):
+                    conf_pred = pred_confs[i]
+                    conf_pred.register_hook(lambda grad, i=i: print(f"Head {i} confidence gradients: {grad.abs().mean().item()}"))
+                    conf_loss = self.bce_obj(conf_pred, conf_tgt).sum()
                     cls_pred = pred_scores[:, :, start:start + nc_i]
                     cls_tgt = target_scores[:, :, start:start + nc_i]
                     cls_loss = self.bce[i](cls_pred, cls_tgt.to(dtype)).sum()
-                    cls_losses.append(cls_loss)
                     LOGGER.debug(f"head{i}_cls_loss: {cls_loss.item()}")
+                    print(f"Head {i} - Conf Loss: {conf_loss.item():.4f}, Class Loss: {cls_loss.item():.4f}")
+                    cls_losses.append(cls_loss)
+                    conf_losses.append(conf_loss)
                     start += nc_i
-                loss[1] = sum(cls_losses) / target_scores_sum
+                loss[1] = (sum(cls_losses) / target_scores_sum) + (sum(conf_losses) / conf_tgt.numel())
             else:
                 loss[1] = self.bce(pred_scores, target_scores.to(dtype)).sum() / target_scores_sum  # BCE
         elif isinstance(self.bce, (VarifocalLoss, QualityfocalLoss)):
@@ -385,16 +393,22 @@ class v8DetectionLoss:
 
             if self.is_multihead:
                 start = 0
-                cls_losses = []
+                cls_losses, conf_losses = [], []
+                conf_tgt = fg_mask.float().unsqueeze(-1)
                 for i, nc_i in enumerate(self.num_classes_per_head):
+                    conf_pred = pred_confs[i]
+                    conf_pred.register_hook(lambda grad, i=i: print(f"Head {i} confidence gradients: {grad.abs().mean().item()}"))
+                    conf_loss = self.bce_obj(conf_pred, conf_tgt).sum()
                     cls_pred = pred_scores[:, :, start:start + nc_i]
                     cls_tgt = cls_iou_targets[:, :, start:start + nc_i]
                     mask = targets_onehot[:, :, start:start + nc_i]
                     cls_loss = self.bce[i](pred=cls_pred, label=cls_tgt.to(dtype), gt_target_pos_mask=mask.to(torch.bool)).sum()
-                    cls_losses.append(cls_loss)
                     LOGGER.debug(f"head{i}_cls_loss: {cls_loss.item()}")
+                    print(f"Head {i} - Conf Loss: {conf_loss.item():.4f}, Class Loss: {cls_loss.item():.4f}")
+                    cls_losses.append(cls_loss)
+                    conf_losses.append(conf_loss)
                     start += nc_i
-                loss[1] = sum(cls_losses) / max(fg_mask.sum(), 1)
+                loss[1] = (sum(cls_losses) / max(fg_mask.sum(), 1)) + (sum(conf_losses) / conf_tgt.numel())
             else:
                 loss[1] = self.bce(
                     pred=pred_scores,


### PR DESCRIPTION
## Summary
- train multi-head detection confidence channels
- keep all class columns in label processing
- manage multi-head predictions in Results.Box
- expose gradient and dataset debug info
- ensure dataset loader outputs all class columns
- add tests for new behaviours

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DCNv4')*

------
https://chatgpt.com/codex/tasks/task_e_687cf158915c832c8449b0215ce62b34