### PR TITLE
Обновление версий Python и библиотек в зависимостях

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ name = "ultralytics"
 dynamic = ["version"]
 description = "Ultralytics YOLO for SOTA object detection, multi-object tracking, instance segmentation, pose estimation and image classification."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 license = { "text" = "AGPL-3.0" }
 keywords = ["machine-learning", "deep-learning", "computer-vision", "ML", "DL", "AI", "YOLO", "YOLOv3", "YOLOv5", "YOLOv8", "YOLOv9", "YOLOv10", "YOLO11", "HUB", "Ultralytics"]
 authors = [
@@ -77,7 +77,7 @@ dependencies = [
     "pandas>=1.1.4",
     "seaborn>=0.11.0", # plotting
     "ultralytics-thop>=2.0.0", # FLOPs computation https://github.com/ultralytics/thop
-    "albumentations>=1.4.14",
+    "albumentations>=2.0.8",
     "timm",
     "efficientnet_pytorch==0.7.1",
     "torch_pruning==1.4.3",
@@ -127,7 +127,7 @@ logging = [
 extra = [
     "hub-sdk>=0.0.12", # Ultralytics HUB
     "ipython", # interactive notebook
-    "albumentations>=1.4.6", # training augmentations
+    "albumentations>=2.0.8", # training augmentations
     "pycocotools>=2.0.7", # COCO mAP
 ]
 


### PR DESCRIPTION
В пайплайне SAHI-обучения используется класс `AtLeastOneBBoxRandomCrop` из albumentations. Для его корректной работы нужны более новые версии:

- `albumentations` - он был добавлен в библиотеку относительно недавно
- `Python` - для корректной работы функции семплирования бокса, которая используется под капотом, нужен Python3.12+, так как лишь начиная с этой версии встроенная функция случайного семплинга корректно обрабатывает `np.ndarray`. См. https://github.com/albumentations-team/AlbumentationsX/pull/106